### PR TITLE
Downgrade flutter version to work with beta 3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,4 +40,4 @@ flutter:
 
 environment:
   sdk: ">=1.19.0 <3.0.0"
-  flutter: ">=0.3.6 <2.0.0"
+  flutter: ">=0.3.2 <2.0.0"


### PR DESCRIPTION
Flutter Beta 3 is 0.3.2, and it looks like lottie works with it properly, so I'd like to downgrade the required version in the yaml to >=0.3.2