### PR TITLE
Various Fixes

### DIFF
--- a/lib/src/animations.dart
+++ b/lib/src/animations.dart
@@ -261,6 +261,11 @@ class SplitDimensionPathKeyframeAnimation extends KeyframeAnimation<Offset> {
   }
 
   @override
+  Offset get value {
+    return new Offset(xAnimation.value, yAnimation.value);
+  }
+
+  @override
   Offset getValue(Keyframe<Offset> keyframe, double keyframeProgress) {
     return new Offset(xAnimation.value, yAnimation.value);
   }

--- a/lib/src/drawing/elements/paths.dart
+++ b/lib/src/drawing/elements/paths.dart
@@ -133,8 +133,8 @@ class MergePathsDrawable extends AnimationDrawable implements PathContent {
     }
 
     // TODO: figure out why this is broken.
-    // this is broken in android as well - just doesn't show up because it's usually disabled. this fixes some stuff for motorcycle.json
-    return Path.combine(PathOperation.union, firstPath, remainderPath);
+    // this is broken in android as well - just doesn't show up because it's usually disabled.
+    return Path.combine(op, firstPath, remainderPath);
 
     // firstPath.op(op, firstPath, remainderPath);
     // return firstPath;

--- a/lib/src/drawing/elements/paths.dart
+++ b/lib/src/drawing/elements/paths.dart
@@ -83,7 +83,9 @@ class MergePathsDrawable extends AnimationDrawable implements PathContent {
       case MergePathsMode.Subtract:
         return opFirstPathWithRest(PathOperation.reverseDifference);
       case MergePathsMode.Intersect:
-        return opFirstPathWithRest(PathOperation.intersect);
+        // TODO: figure out why this is broken.
+        // return opFirstPathWithRest(PathOperation.intersect);
+        return opFirstPathWithRest(PathOperation.union);
       case MergePathsMode.ExcludeIntersections:
         return opFirstPathWithRest(PathOperation.xor);
       default:

--- a/lib/src/painting.dart
+++ b/lib/src/painting.dart
@@ -8,7 +8,7 @@ class Mask {
 
   Mask.fromMap(dynamic map, double scale, double durationFrames)
       : mode = calculateMode(map['mode']),
-        path = new AnimatableShapeValue.fromMap(map, scale, durationFrames);
+        path = new AnimatableShapeValue.fromMap(map['pt'], scale, durationFrames);
 
   static MaskMode calculateMode(String rawMode) {
     switch (rawMode) {


### PR DESCRIPTION
- Fix mask parsing (should fix #6)
- Fix SplitDimensionPathKeyframeAnimation
- Restore path combine op (even if not perfect, we found out it's actually working as intended in our animations)