### PR TITLE
Fix Controller initial value

### DIFF
--- a/lib/src/lottie.dart
+++ b/lib/src/lottie.dart
@@ -56,6 +56,7 @@ class _LottieState extends State<Lottie> with SingleTickerProviderStateMixin {
           vsync: this,
         )..repeat());
 
+    _compositionLayer?.progress = _animation.value;
     _animation.addListener(_handleChange);
   }
 


### PR DESCRIPTION
Previously the lottie composition layer was not updated with its initial value.