### PR TITLE
Dispose the animation controller only if it is created by Lottie itself

### DIFF
--- a/lib/src/lottie.dart
+++ b/lib/src/lottie.dart
@@ -34,6 +34,7 @@ class Lottie extends StatefulWidget {
 class _LottieState extends State<Lottie> with SingleTickerProviderStateMixin {
   CompositionLayer _compositionLayer;
   AnimationController _animation;
+  bool _shouldDisposeAnimation;
   double _scale;
 
   @override
@@ -46,6 +47,8 @@ class _LottieState extends State<Lottie> with SingleTickerProviderStateMixin {
       widget._controller.duration =
           new Duration(milliseconds: widget._composition.duration);
     }
+
+    _shouldDisposeAnimation = widget._controller == null;
 
     _animation = widget._controller ??
         (new AnimationController(
@@ -118,7 +121,11 @@ class _LottieState extends State<Lottie> with SingleTickerProviderStateMixin {
   @override
   void dispose() {
     _animation.removeListener(_handleChange);
-    _animation.dispose();
+
+    if (_shouldDisposeAnimation) {
+      _animation.dispose();
+    }
+
     super.dispose();
   }
 }


### PR DESCRIPTION
The Animation controller should be disposed by the widget that creates it. This PR ensures to avoid disposing it if it is passed from an outer widget and not automatically created/managed by the Lottie widget itself